### PR TITLE
advanced part5: add credentialsProvider with dummy user

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,0 +1,39 @@
+import NextAuth from "next-auth"
+import GithubProvider from "next-auth/providers/github"
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export const authOptions = {
+  // Configure one or more authentication providers
+  providers: [
+    GithubProvider({
+      clientId: process.env.GITHUB_ID,
+      clientSecret: process.env.GITHUB_SECRET,
+    }),
+    CredentialsProvider({
+      name: "credentials",
+      credentials: {
+        username: { label: "Username", type: "text", placeholder: "username" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (
+          credentials.username === "fisch" &&
+          credentials.password === "fisch"
+        ) {
+          return {
+            name: "Neuer Fisch",
+            email: "test@example.com",
+          };
+        } else {
+          return null;
+        }
+      },
+    }),
+
+
+    // ...add more providers here
+    
+  ],
+}
+
+export default NextAuth(authOptions)


### PR DESCRIPTION
commit 1: Add credentialsProvider to `api/auth/[...nextauth],js` and include a dummy user